### PR TITLE
Change the shaded pattern to org.cloudfoundry.reconfiguration.tomee.*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,11 +113,11 @@
                             <relocations>
                                 <relocation>
                                     <pattern>org.springframework.cloud</pattern>
-                                    <shadedPattern>org.cloudfoundry.reconfiguration.org.springframework.cloud</shadedPattern>
+                                    <shadedPattern>org.cloudfoundry.reconfiguration.tomee.org.springframework.cloud</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>^META-INF/services/org.springframework.cloud</pattern>
-                                    <shadedPattern>META-INF/services/org.cloudfoundry.reconfiguration.org.springframework.cloud</shadedPattern>
+                                    <shadedPattern>META-INF/services/org.cloudfoundry.reconfiguration.tomee.org.springframework.cloud</shadedPattern>
                                     <rawString>true</rawString>
                                 </relocation>
                             </relocations>


### PR DESCRIPTION
Both artifacts tomee buildpack resource configuration and spring auto
reconfiguration use one and the same pattern for shading the package
org.springframework.cloud._. This causes problems during runtime
when both artifacts are in the classpath. Because of this tomee
buildpack resource configuration will use a new pattern -
org.cloudfoundry.reconfiguration.tomee._
